### PR TITLE
Add confirmation before creating the Pull Request and release/install scripts

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12,6 +12,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "ansi_term"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d52a9bb7ec0cf484c551830a7ce27bd20d67eac647e1befb56b0be4ee39a55d2"
+dependencies = [
+ "winapi",
+]
+
+[[package]]
+name = "atty"
+version = "0.2.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9b39be18770d11421cdb1b9947a45dd3f37e93092cbf377614828a319d5fee8"
+dependencies = [
+ "hermit-abi",
+ "libc",
+ "winapi",
+]
+
+[[package]]
 name = "autocfg"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -58,6 +78,21 @@ name = "cfg-if"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
+
+[[package]]
+name = "clap"
+version = "2.34.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a0610544180c38b88101fecf2dd634b174a62eef6946f84dfc6a7127512b381c"
+dependencies = [
+ "ansi_term",
+ "atty",
+ "bitflags",
+ "strsim",
+ "textwrap",
+ "unicode-width",
+ "vec_map",
+]
 
 [[package]]
 name = "core-foundation"
@@ -218,6 +253,15 @@ name = "hashbrown"
 version = "0.12.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "607c8a29735385251a339424dd462993c0fed8fa09d378f259377df08c126022"
+
+[[package]]
+name = "heck"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d621efb26863f0e9924c6ac577e8275e5e6b77455db64ffa6c65c904e9e132c"
+dependencies = [
+ "unicode-segmentation",
+]
 
 [[package]]
 name = "hermit-abi"
@@ -560,9 +604,34 @@ dependencies = [
  "reqwest",
  "serde",
  "serde_json",
+ "structopt",
  "termion",
  "tokio",
  "tui",
+]
+
+[[package]]
+name = "proc-macro-error"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da25490ff9892aab3fcf7c36f08cfb902dd3e71ca0f9f9517bea02a73a5ce38c"
+dependencies = [
+ "proc-macro-error-attr",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "version_check",
+]
+
+[[package]]
+name = "proc-macro-error-attr"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1be40180e52ecc98ad80b184934baf3d0d29f979574e439af5a55274b35f869"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "version_check",
 ]
 
 [[package]]
@@ -784,6 +853,36 @@ dependencies = [
 ]
 
 [[package]]
+name = "strsim"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a"
+
+[[package]]
+name = "structopt"
+version = "0.3.26"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c6b5c64445ba8094a6ab0c3cd2ad323e07171012d9c98b0b15651daf1787a10"
+dependencies = [
+ "clap",
+ "lazy_static",
+ "structopt-derive",
+]
+
+[[package]]
+name = "structopt-derive"
+version = "0.4.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dcb5ae327f9cc13b68763b5749770cb9e048a99bd9dfdfa58d0cf05d5f64afe0"
+dependencies = [
+ "heck",
+ "proc-macro-error",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "syn"
 version = "1.0.98"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -818,6 +917,15 @@ dependencies = [
  "numtoa",
  "redox_syscall",
  "redox_termios",
+]
+
+[[package]]
+name = "textwrap"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d326610f408c7a4eb6f51c37c330e496b08506c9457c9d34287ecc38809fb060"
+dependencies = [
+ "unicode-width",
 ]
 
 [[package]]
@@ -985,6 +1093,18 @@ name = "vcpkg"
 version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
+
+[[package]]
+name = "vec_map"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1bddf1187be692e79c5ffeab891132dfb0f236ed36a43c7ed39f1165ee20191"
+
+[[package]]
+name = "version_check"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
 
 [[package]]
 name = "want"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -613,7 +613,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1df8c4ec4b0627e53bdf214615ad287367e482558cf84b109250b37464dc03ae"
 
 [[package]]
-name = "pr_opener"
+name = "pr"
 version = "0.1.0"
 dependencies = [
  "console",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -95,6 +95,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "console"
+version = "0.15.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c926e00cc70edefdc64d3a5ff31cc65bb97a3460097762bd23afb4d8145fccf8"
+dependencies = [
+ "encode_unicode",
+ "lazy_static",
+ "libc",
+ "unicode-width",
+ "windows-sys 0.45.0",
+]
+
+[[package]]
 name = "core-foundation"
 version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -131,6 +144,12 @@ name = "either"
 version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f107b87b6afc2a64fd13cac55fe06d6c8859f12d4b14cbcdd2c67d0976781be"
+
+[[package]]
+name = "encode_unicode"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a357d28ed41a50f9c765dbfe56cbc04a64e53e5fc58ba79fbc34c10ef3df831f"
 
 [[package]]
 name = "encoding_rs"
@@ -458,7 +477,7 @@ dependencies = [
  "libc",
  "log",
  "wasi",
- "windows-sys",
+ "windows-sys 0.36.1",
 ]
 
 [[package]]
@@ -566,7 +585,7 @@ dependencies = [
  "libc",
  "redox_syscall",
  "smallvec",
- "windows-sys",
+ "windows-sys 0.36.1",
 ]
 
 [[package]]
@@ -597,6 +616,7 @@ checksum = "1df8c4ec4b0627e53bdf214615ad287367e482558cf84b109250b37464dc03ae"
 name = "pr"
 version = "0.1.0"
 dependencies = [
+ "console",
  "dotenv",
  "edit",
  "loading",
@@ -746,7 +766,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "88d6731146462ea25d9244b2ed5fd1d716d25c52e4d54aa4fb0f3c4e9854dbe2"
 dependencies = [
  "lazy_static",
- "windows-sys",
+ "windows-sys 0.36.1",
 ]
 
 [[package]]
@@ -1237,12 +1257,42 @@ version = "0.36.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ea04155a16a59f9eab786fe12a4a450e75cdb175f9e0d80da1e17db09f55b8d2"
 dependencies = [
- "windows_aarch64_msvc",
- "windows_i686_gnu",
- "windows_i686_msvc",
- "windows_x86_64_gnu",
- "windows_x86_64_msvc",
+ "windows_aarch64_msvc 0.36.1",
+ "windows_i686_gnu 0.36.1",
+ "windows_i686_msvc 0.36.1",
+ "windows_x86_64_gnu 0.36.1",
+ "windows_x86_64_msvc 0.36.1",
 ]
+
+[[package]]
+name = "windows-sys"
+version = "0.45.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75283be5efb2831d37ea142365f009c02ec203cd29a3ebecbc093d52315b66d0"
+dependencies = [
+ "windows-targets",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e5180c00cd44c9b1c88adb3693291f1cd93605ded80c250a75d472756b4d071"
+dependencies = [
+ "windows_aarch64_gnullvm",
+ "windows_aarch64_msvc 0.42.2",
+ "windows_i686_gnu 0.42.2",
+ "windows_i686_msvc 0.42.2",
+ "windows_x86_64_gnu 0.42.2",
+ "windows_x86_64_gnullvm",
+ "windows_x86_64_msvc 0.42.2",
+]
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "597a5118570b68bc08d8d59125332c54f1ba9d9adeedeef5b99b02ba2b0698f8"
 
 [[package]]
 name = "windows_aarch64_msvc"
@@ -1251,10 +1301,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9bb8c3fd39ade2d67e9874ac4f3db21f0d710bee00fe7cab16949ec184eeaa47"
 
 [[package]]
+name = "windows_aarch64_msvc"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e08e8864a60f06ef0d0ff4ba04124db8b0fb3be5776a5cd47641e942e58c4d43"
+
+[[package]]
 name = "windows_i686_gnu"
 version = "0.36.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "180e6ccf01daf4c426b846dfc66db1fc518f074baa793aa7d9b9aaeffad6a3b6"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c61d927d8da41da96a81f029489353e68739737d3beca43145c8afec9a31a84f"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -1263,16 +1325,40 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e2e7917148b2812d1eeafaeb22a97e4813dfa60a3f8f78ebe204bcc88f12f024"
 
 [[package]]
+name = "windows_i686_msvc"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44d840b6ec649f480a41c8d80f9c65108b92d89345dd94027bfe06ac444d1060"
+
+[[package]]
 name = "windows_x86_64_gnu"
 version = "0.36.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4dcd171b8776c41b97521e5da127a2d86ad280114807d0b2ab1e462bc764d9e1"
 
 [[package]]
+name = "windows_x86_64_gnu"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8de912b8b8feb55c064867cf047dda097f92d51efad5b491dfb98f6bbb70cb36"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26d41b46a36d453748aedef1486d5c7a85db22e56aff34643984ea85514e94a3"
+
+[[package]]
 name = "windows_x86_64_msvc"
 version = "0.36.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c811ca4a8c853ef420abd8592ba53ddbbac90410fab6903b3e79972a631f7680"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9aec5da331524158c6d1a4ac0ab1541149c0b9505fde06423b02f5ef0106b9f0"
 
 [[package]]
 name = "winreg"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -95,6 +95,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "console"
+version = "0.15.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c926e00cc70edefdc64d3a5ff31cc65bb97a3460097762bd23afb4d8145fccf8"
+dependencies = [
+ "encode_unicode",
+ "lazy_static",
+ "libc",
+ "unicode-width",
+ "windows-sys 0.45.0",
+]
+
+[[package]]
 name = "core-foundation"
 version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -131,6 +144,12 @@ name = "either"
 version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f107b87b6afc2a64fd13cac55fe06d6c8859f12d4b14cbcdd2c67d0976781be"
+
+[[package]]
+name = "encode_unicode"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a357d28ed41a50f9c765dbfe56cbc04a64e53e5fc58ba79fbc34c10ef3df831f"
 
 [[package]]
 name = "encoding_rs"
@@ -458,7 +477,7 @@ dependencies = [
  "libc",
  "log",
  "wasi",
- "windows-sys",
+ "windows-sys 0.36.1",
 ]
 
 [[package]]
@@ -566,7 +585,7 @@ dependencies = [
  "libc",
  "redox_syscall",
  "smallvec",
- "windows-sys",
+ "windows-sys 0.36.1",
 ]
 
 [[package]]
@@ -597,6 +616,7 @@ checksum = "1df8c4ec4b0627e53bdf214615ad287367e482558cf84b109250b37464dc03ae"
 name = "pr_opener"
 version = "0.1.0"
 dependencies = [
+ "console",
  "dotenv",
  "edit",
  "loading",
@@ -746,7 +766,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "88d6731146462ea25d9244b2ed5fd1d716d25c52e4d54aa4fb0f3c4e9854dbe2"
 dependencies = [
  "lazy_static",
- "windows-sys",
+ "windows-sys 0.36.1",
 ]
 
 [[package]]
@@ -1237,12 +1257,42 @@ version = "0.36.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ea04155a16a59f9eab786fe12a4a450e75cdb175f9e0d80da1e17db09f55b8d2"
 dependencies = [
- "windows_aarch64_msvc",
- "windows_i686_gnu",
- "windows_i686_msvc",
- "windows_x86_64_gnu",
- "windows_x86_64_msvc",
+ "windows_aarch64_msvc 0.36.1",
+ "windows_i686_gnu 0.36.1",
+ "windows_i686_msvc 0.36.1",
+ "windows_x86_64_gnu 0.36.1",
+ "windows_x86_64_msvc 0.36.1",
 ]
+
+[[package]]
+name = "windows-sys"
+version = "0.45.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75283be5efb2831d37ea142365f009c02ec203cd29a3ebecbc093d52315b66d0"
+dependencies = [
+ "windows-targets",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e5180c00cd44c9b1c88adb3693291f1cd93605ded80c250a75d472756b4d071"
+dependencies = [
+ "windows_aarch64_gnullvm",
+ "windows_aarch64_msvc 0.42.2",
+ "windows_i686_gnu 0.42.2",
+ "windows_i686_msvc 0.42.2",
+ "windows_x86_64_gnu 0.42.2",
+ "windows_x86_64_gnullvm",
+ "windows_x86_64_msvc 0.42.2",
+]
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "597a5118570b68bc08d8d59125332c54f1ba9d9adeedeef5b99b02ba2b0698f8"
 
 [[package]]
 name = "windows_aarch64_msvc"
@@ -1251,10 +1301,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9bb8c3fd39ade2d67e9874ac4f3db21f0d710bee00fe7cab16949ec184eeaa47"
 
 [[package]]
+name = "windows_aarch64_msvc"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e08e8864a60f06ef0d0ff4ba04124db8b0fb3be5776a5cd47641e942e58c4d43"
+
+[[package]]
 name = "windows_i686_gnu"
 version = "0.36.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "180e6ccf01daf4c426b846dfc66db1fc518f074baa793aa7d9b9aaeffad6a3b6"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c61d927d8da41da96a81f029489353e68739737d3beca43145c8afec9a31a84f"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -1263,16 +1325,40 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e2e7917148b2812d1eeafaeb22a97e4813dfa60a3f8f78ebe204bcc88f12f024"
 
 [[package]]
+name = "windows_i686_msvc"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44d840b6ec649f480a41c8d80f9c65108b92d89345dd94027bfe06ac444d1060"
+
+[[package]]
 name = "windows_x86_64_gnu"
 version = "0.36.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4dcd171b8776c41b97521e5da127a2d86ad280114807d0b2ab1e462bc764d9e1"
 
 [[package]]
+name = "windows_x86_64_gnu"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8de912b8b8feb55c064867cf047dda097f92d51efad5b491dfb98f6bbb70cb36"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26d41b46a36d453748aedef1486d5c7a85db22e56aff34643984ea85514e94a3"
+
+[[package]]
 name = "windows_x86_64_msvc"
 version = "0.36.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c811ca4a8c853ef420abd8592ba53ddbbac90410fab6903b3e79972a631f7680"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9aec5da331524158c6d1a4ac0ab1541149c0b9505fde06423b02f5ef0106b9f0"
 
 [[package]]
 name = "winreg"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "pr_opener"
+name = "pr"
 version = "0.1.0"
 edition = "2021"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,3 +32,4 @@ termion = "1.5"
 tui = { version = "0.18", default-features = false, features = ['termion'] }
 
 loading = "*"
+console = "0.15.7"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,7 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+structopt = { version = "0.3" }
 regex = "1.5"
 reqwest = { version = "0.11", features = ["json", "blocking"] }
 tokio = { version = "1", features = ["full"] }

--- a/bin/install.sh
+++ b/bin/install.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+
+# Check if the script is running with sudo
+if [ "$EUID" -ne 0 ]; then
+  echo "Please run this script with sudo."
+  exit 1
+fi
+
+# Fetch the latest release information from GitHub API
+release_info=$(curl --silent "https://api.github.com/repos/jaerod95/pr/releases/latest")
+
+# Parse the download URL of the release asset
+download_url=$(echo "$release_info" | grep -oP '(?<=browser_download_url": ").*(?=")')
+
+# Extract the filename from the download URL
+filename=$(basename "$download_url")
+
+# Download the release binary
+echo "Downloading $filename..."
+curl -LJO "$download_url"
+
+# Make the downloaded binary executable
+chmod +x "$filename"
+
+# Move the binary to /usr/bin
+echo "Moving $filename to /usr/bin..."
+mv "$filename" /usr/bin/pr
+
+echo "Installation completed!"

--- a/bin/release.sh
+++ b/bin/release.sh
@@ -1,0 +1,46 @@
+#!/bin/bash
+
+# Requires semver to be installed `npm install -g semver``
+
+# Check if the current branch is "main"
+branch=$(git rev-parse --abbrev-ref HEAD)
+if [ "$branch" != "main" ]; then
+  echo "This script can only be run on the 'main' branch. Aborting."
+  exit 1
+fi
+
+echo "Which version bump would you like to apply?"
+echo "1. Patch (0.0.1 -> 0.0.2)"
+echo "2. Minor (0.1.0 -> 0.2.0)"
+echo "3. Major (1.0.0 -> 2.0.0)"
+read -p "Enter your choice [1-3]: " choice
+
+case $choice in
+    1)
+        bump="patch"
+        ;;
+    2)
+        bump="minor"
+        ;;
+    3)
+        bump="major"
+        ;;
+    *)
+        echo "Invalid choice. Exiting."
+        exit 1
+        ;;
+esac
+
+current_version=$(grep -oP '(?<=^version = ").*(?="$)' Cargo.toml)
+new_version=$(semver bump $bump $current_version)
+sed -i '' "s/version = \".*\"/version = \"$new_version\"/" Cargo.toml
+
+echo "Updated version: $new_version"
+
+cargo build --release
+release_binary="target/release/pr"
+
+echo "Creating GitHub release..."
+gh release create "v$new_version" "$release_binary" --notes "Release $new_version"
+
+echo "Release created and binary uploaded."

--- a/src/main.rs
+++ b/src/main.rs
@@ -211,7 +211,7 @@ fn get_pr_title(
             let ticket_id = linear_ticket_id.clone().unwrap();
             format!(
                 r"<!--- The title of your pull request. Save and close this file to continue. --->
-                [{ticket_id}] {ticket_title}",
+[{ticket_id}] {ticket_title}",
                 ticket_id = ticket_id,
                 ticket_title = ticket.title
             )
@@ -299,8 +299,6 @@ fn main() {
         .collect::<Vec<&str>>()
         .join("\n");
 
-    dbg!(&pr_title);
-
     let pr_body = get_pr_body(&overview_str, &context_str);
     let pr_body = edit::edit(pr_body)
         .unwrap()
@@ -308,9 +306,6 @@ fn main() {
         .skip(1)
         .collect::<Vec<&str>>()
         .join("\n");
-
-
-        dbg!(&pr_body);
 
     if !args.no_confirm {
         println!("Confirm creating pull request (y): ");

--- a/src/main.rs
+++ b/src/main.rs
@@ -5,45 +5,39 @@ use reqwest;
 use serde::{Deserialize, Deserializer, Serialize};
 use serde_json;
 use std::{env, process::Command};
-
-use loading::Loading;
 use std::thread;
 use std::time::Duration;
+use structopt::StructOpt;
 
-fn exit(message: &str) {
+use loading::Loading;
+
+fn exit(message: &str) -> ! {
     println!("{}", message);
     panic!();
 }
 
-fn verify_dependencies() -> () {
-    // TODO: git is installed
-    // TODO: gh is installed
-    // TODO: gh is authenticated
+fn verify_dependencies() {
+    // TODO: Check if git and gh are installed
+    // TODO: Check if gh is authenticated
     thread::sleep(Duration::from_millis(1000));
 }
 
 fn git(args: &[&str], err_on_std_err: bool) -> String {
-    let mut output = Command::new("git");
-
-    for arg in args {
-        output.arg(arg);
-    }
-
-    let output = output
+    let output = Command::new("git")
+        .args(args)
         .output()
-        .expect("Failed to execute git command '{arg}'");
+        .expect("Failed to execute git command");
 
     if !output.stderr.is_empty() {
         let error_message = String::from_utf8(output.stderr).unwrap();
         if err_on_std_err {
-            exit(&error_message)
+            exit(&error_message);
         }
 
         eprintln!("{}", error_message);
     }
 
-    String::from_utf8(output.stdout)
-        .expect("Failed to convert git command '{arg}' stdout to string")
+    String::from_utf8(output.stdout).expect("Failed to convert git command stdout to string")
 }
 
 // TODO: add support for reading default target from config file
@@ -187,28 +181,21 @@ fn get_linear_ticket(ticket_id: &Option<String>) -> Option<LinearIssue> {
     }
 }
 
-fn get_overview_str(commits: &Vec<Commit>) -> String {
-    let mut overview_str = String::new();
-
-    for (i, commit) in commits.iter().enumerate() {
-        let mut str = format!("- {}", commit.message);
-        if i < commits.len() - 1 {
-            str.push('\n');
-        }
-
-        overview_str.push_str(&str);
-    }
+fn get_overview_str(commits: &[Commit]) -> String {
+    let overview_str = commits
+        .iter()
+        .map(|commit| format!("- {}", commit.message))
+        .collect::<Vec<String>>()
+        .join("\n");
 
     overview_str
 }
 
 fn get_context_str(linear_ticket: &Option<LinearIssue>) -> String {
-    match &linear_ticket {
-        None => String::new(),
-        Some(ticket) => {
-            format!("{}\n\n{}", &ticket.url, &ticket.description)
-        }
-    }
+    linear_ticket
+        .as_ref()
+        .map(|ticket| format!("{}\n\n{}", ticket.url, ticket.description))
+        .unwrap_or_default()
 }
 
 // TODO: If no name has been generated, should open an editor for it / prompt for it
@@ -216,17 +203,15 @@ fn get_pr_title(
     linear_ticket: &Option<LinearIssue>,
     linear_ticket_id: &Option<String>,
 ) -> Option<String> {
-    match &linear_ticket {
-        None => None,
-        Some(ticket) => {
-            let ticket_id = linear_ticket_id.clone().unwrap();
-            let ticket_title = &ticket.title;
-            Some(format!(
-                r"<!--- The title of your pull request. Save and close this file to continue. --->
-[{ticket_id}] {ticket_title}"
-            ))
-        }
-    }
+    linear_ticket.as_ref().map(|ticket| {
+        let ticket_id = linear_ticket_id.clone().unwrap();
+        format!(
+            r"<!--- The title of your pull request. Save and close this file to continue. --->
+[{ticket_id}] {ticket_title}",
+            ticket_id = ticket_id,
+            ticket_title = ticket.title
+        )
+    })
 }
 
 fn get_pr_body(overview: &str, context: &str) -> String {
@@ -242,12 +227,24 @@ fn get_pr_body(overview: &str, context: &str) -> String {
 
 ## Test Plan
 
-"
+",
+        overview = overview,
+        context = context
     )
+}
+
+#[derive(Debug, StructOpt)]
+#[structopt(name = "pr-cli", about = "Create a pull request")]
+struct CliArgs {
+    /// Skip confirmation prompt
+    #[structopt(long)]
+    no_confirm: bool,
 }
 
 fn main() {
     dotenv::dotenv().ok();
+
+    let args = CliArgs::from_args();
 
     let loading = Loading::default();
 
@@ -304,6 +301,19 @@ fn main() {
         .collect::<Vec<&str>>()
         .join("\n");
 
+    if !args.no_confirm {
+        loading.text("Confirm creating pull request (y): ");
+        let mut confirmation = String::new();
+        std::io::stdin()
+            .read_line(&mut confirmation)
+            .expect("Failed to read input");
+        if !confirmation.trim().eq_ignore_ascii_case("y") {
+            loading.text("Pull request creation aborted.");
+            loading.end();
+            return;
+        }
+    }
+
     let loading = Loading::default();
 
     loading.text("Pushing branch upstream..");
@@ -323,8 +333,8 @@ fn main() {
         .output()
         .unwrap();
 
-    let gh_output_stderr = String::from_utf8(gh_output.clone().stderr).unwrap();
-    if gh_output_stderr.len() > 0 {
+    let gh_output_stderr = String::from_utf8_lossy(&gh_output.stderr);
+    if !gh_output_stderr.is_empty() {
         loading.fail("Failed to create PR!");
         loading.end();
 
@@ -332,7 +342,7 @@ fn main() {
         return;
     }
 
-    let gh_output_stdout = String::from_utf8(gh_output.stdout).unwrap();
+    let gh_output_stdout = String::from_utf8_lossy(&gh_output.stdout);
     let pr_url = gh_output_stdout.trim();
 
     loading.success(format!("PR opened successfully: {}", pr_url));

--- a/src/main.rs
+++ b/src/main.rs
@@ -5,7 +5,6 @@ use regex::Regex;
 use reqwest;
 use serde::{Deserialize, Deserializer, Serialize};
 use serde_json;
-use std::io::{self, Read};
 use std::{env, process::Command};
 use std::thread;
 use std::time::Duration;


### PR DESCRIPTION
## Overview

Adds new confirmation input before creating the pull request so the user can abort. Can be disabled by passing the `--no-confirm` flag.

Also adds a new `release.sh` script to generate github releases and a `install.sh` script for installing the latest version from github.

- new prompt check
- add confirmation prompt
- add confirmation before opening the pr
- remove unused dependency
- Add release script
- new prompt check
- add confirmation prompt
- add confirmation before opening the pr
- remove unused dependency
- Add release script
- Add install scirpt
- Merge branch 'jrod/dit-4395-test-ticket' of https://github.com/jaerod95/pr into jrod/dit-4395-test-ticket
